### PR TITLE
Dependency

### DIFF
--- a/__resource.lua
+++ b/__resource.lua
@@ -2,5 +2,6 @@
 --- Discord Whitelist, Made by FAXES ---
 ----------------------------------------
 resource_manifest_version "44febabe-d386-4d18-afbe-5e627f4af937"
+dependency 'discord_perms'
 
 server_script "server.lua"


### PR DESCRIPTION
Make use of manifest dependency var to ensure that the dependency is loaded before the DiscordWhitelist resource.

This addition will also ensure that people are naming the dependency correctly. Your exports will not be accessible if it is not named correctly.

https://docs.fivem.net/scripting-reference/resource-manifest/resource-manifest/